### PR TITLE
[feature]: creator can now remove their collections from the registry

### DIFF
--- a/services/src/collections/registry.lua
+++ b/services/src/collections/registry.lua
@@ -134,7 +134,7 @@ end)
 
 -- Remove collection by ID
 Handlers.add('Remove-Collection', Handlers.utils.hasMatchingTag('Action', 'Remove-Collection'), function(msg)
-	if msg.From ~= Owner and msg.From ~= ao.id then
+	if msg.From ~= Owner and msg.From ~= ao.id and msg.From ~= collectionOwner then
 		ao.send({
 			Target = msg.From,
 			Action = 'Authorization-Error',
@@ -145,7 +145,7 @@ Handlers.add('Remove-Collection', Handlers.utils.hasMatchingTag('Action', 'Remov
 		})
 		return
 	end
-
+	
 	local collectionId = msg.Tags.CollectionId
 
 	if not collectionId or collectionId == '' then


### PR DESCRIPTION
This PR updates the access control logic in the registry process to allow **collection creators** to remove their own collections — alongside the existing permissions for the registry owner and the AO process.

Logic added:
```lua
if msg.From ~= Owner and msg.From ~= ao.id and msg.From ~= collectionOwner then
  -- deny removal
end
```

This allows collection removal by:
- The registry process owner
- The AO process itself
- The original collection creator (`collectionOwner`)
