### PR TITLE
track portal id using Metadata

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@permaweb/libs",
-	"version": "0.0.61",
+	"version": "0.0.62",
 	"type": "module",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",

--- a/sdk/src/helpers/types.ts
+++ b/sdk/src/helpers/types.ts
@@ -2,7 +2,7 @@ export type DependencyType = {
 	ao: any;
 	signer?: any;
 	arweave?: any;
-	node?: { url: string, scheduler: string, authority: string };
+	node?: { url: string; scheduler: string; authority: string };
 };
 
 export type ProcessReadType = {
@@ -133,6 +133,7 @@ export type CommentCreateArgType = {
 	parentId?: string;
 	rootId?: string;
 	tags?: TagType[];
+	metadata?: object;
 };
 
 export type CollectionManifestType = {

--- a/sdk/src/services/comments.ts
+++ b/sdk/src/services/comments.ts
@@ -10,6 +10,7 @@ export function createCommentWith(deps: DependencyType) {
 
 			const tags = [];
 			if (args.parentId) tags.push({ name: 'Parent-Id', value: args.parentId });
+			if (args.metadata) tags.push({ name: 'Metadata', value: JSON.stringify(args.metadata) });
 
 			const commentsUpdateId = await aoSend(deps, {
 				processId: args.commentsId,
@@ -165,4 +166,3 @@ export function unpinCommentWith(deps: DependencyType) {
 		}
 	};
 }
-

--- a/services/src/process_comments.lua
+++ b/services/src/process_comments.lua
@@ -253,7 +253,7 @@ Handlers.add("Add-Comment", "Add-Comment", function(msg)
 		ParentId = parentId,
 		Depth = depth,
 		ChildrenCount = 0,
-		Metadata = {},
+		Metadata = msg.Metadata or {},
 	}
 
 	table.insert(Comments, newComment)


### PR DESCRIPTION
Now in the `createComment` - metadata can be passed - thats a JSON field that can be used to track origin portal id and stuff